### PR TITLE
refactor:去除@react-native-oh-tpl/react-native-spring-scrollview的npm依赖配置

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
 	},
 	"homepage": "https://github.com/bolan9999/react-native-largelist",
 	"peerDependencies": {
-		"prop-types": "^15.6.0",
-		"@react-native-oh-tpl/react-native-spring-scrollview": "^2.0.22-0.0.3"
+		"prop-types": "^15.6.0"
 	},
 	"devDependencies": {
 		"babel-jest": "21.2.0",


### PR DESCRIPTION
# Summary

- 去除@react-native-oh-tpl/react-native-spring-scrollview的npm依赖配置
- Close: #4 

## Test Plan

- 使用react-native-largelist的demo，配置@react-native-oh-tpl/react-native-spring-scrollview最新版本验证
- 已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
